### PR TITLE
Include buffer contents in error message

### DIFF
--- a/uuid-buffer.ts
+++ b/uuid-buffer.ts
@@ -9,9 +9,9 @@ export function toBuffer(uuid:string):Buffer {
 }
 
 export function toString(buffer:Buffer):string {
-  if (buffer.length != 16) throw new Error(`Invalid buffer length for uuid: ${buffer.length}`);
-  if (buffer.equals(Buffer.alloc(16))) return null; // If buffer is all zeros, return null
   const str = buffer.toString('hex');
+  if (buffer.length != 16) throw new Error(`Invalid buffer length for uuid: ${buffer.length}. Buffer contents: ${str}`);
+  if (buffer.equals(Buffer.alloc(16))) return null; // If buffer is all zeros, return null
   return `${str.slice(0, 8)}-${str.slice(8, 12)}-${str.slice(12, 16)}-${str.slice(16, 20)}-${str.slice(20)}`;
 }
 


### PR DESCRIPTION
I feel like this would be a small but meaningful improvement to the usability of the error message. 